### PR TITLE
Support operator

### DIFF
--- a/example/TestMetaData.h
+++ b/example/TestMetaData.h
@@ -140,7 +140,7 @@ namespace decision_tree { namespace details {
     struct MetaDataUtil<TestMetaData>
     {
         static bool is_same(const ConditionCheck<TestMetaData>* c1, const ConditionCheck<TestMetaData>* c2) {
-            if (c1->_targetType != c2->_targetType || c1->_checker != c2->_checker || c1->_attr != c2->_attr || c1->_op != c2->_op)
+            if (c1->_targetType != c2->_targetType || c1->_checker != c2->_checker || c1->_attr != c2->_attr)
                 return false;
             switch (c1->_targetType)
             {
@@ -181,14 +181,13 @@ namespace decision_tree { namespace details {
             return (ConditionCheck<TestMetaData>*)check;
         }
 
-        template<typename Target>
-        static ConditionCheck<TestMetaData>* buildCompare(details::utils::member_attr_func_t<TestMetaData::CheckT, std::conditional_t<!utils::pass_by_value_v<Target>, const Target&, Target>> attr_, const Target& target_, details::comp::Op op_)
+        template<typename Target, typename Op>
+        static ConditionCheck<TestMetaData>* buildCompare(details::utils::member_attr_func_t<TestMetaData::CheckT, std::conditional_t<!utils::pass_by_value_v<Target>, const Target&, Target>> attr_, const Target& target_, Op)
         {
             auto check = new _ConditionCheck<TestMetaData, std::decay_t<Target>>();
             check->_targetType = TestMetaData::getTypeName<Target>();
-            check->_op = op_;
             check->_data = target_;
-            check->_checker._comp = &comp::compare<Target>;
+            check->_checker._comp = &comp::compare<Target, Op>;
             check->_attr = attr_;
             return (ConditionCheck<TestMetaData>*)check;
         }
@@ -202,7 +201,6 @@ namespace decision_tree { namespace details {
                 using type = TestMetaData::getType<TestMetaData::ParamType::CHAR>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
                 in_check->_targetType = check_->_targetType;
-                in_check->_op = check_->_op;
                 in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
                 memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
@@ -214,7 +212,6 @@ namespace decision_tree { namespace details {
                 using type = TestMetaData::getType<TestMetaData::ParamType::INT>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
                 in_check->_targetType = check_->_targetType;
-                in_check->_op = check_->_op;
                 in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
                 memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
@@ -226,7 +223,6 @@ namespace decision_tree { namespace details {
                 using type = TestMetaData::getType<TestMetaData::ParamType::DOUBLE>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
                 in_check->_targetType = check_->_targetType;
-                in_check->_op = check_->_op;
                 in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
                 memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
@@ -238,7 +234,6 @@ namespace decision_tree { namespace details {
                 using type = TestMetaData::getType<TestMetaData::ParamType::STRING>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
                 in_check->_targetType = check_->_targetType;
-                in_check->_op = check_->_op;
                 in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
                 memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
@@ -290,56 +285,56 @@ namespace decision_tree { namespace details {
             case TestMetaData::ParamType::CHAR:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::CHAR>::type;
-                if (check_->_op == details::comp::Op::Invalid) {
+                if (check_->_attr == nullptr) {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
                     return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
                 }
                 else {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
                     auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
-                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data));
                 }
                 break;
             }
             case TestMetaData::ParamType::DOUBLE:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::DOUBLE>::type;
-                if (check_->_op == details::comp::Op::Invalid) {
+                if (check_->_attr == nullptr) {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
                     return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
                 }
                 else {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
                     auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
-                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data));
                 }
                 break;
             }
             case TestMetaData::ParamType::INT:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::INT>::type;
-                if (check_->_op == details::comp::Op::Invalid) {
+                if (check_->_attr == nullptr) {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
                     return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
                 }
                 else {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
                     auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
-                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data));
                 }
                 break;
             }
             case TestMetaData::ParamType::STRING:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::STRING>::type;
-                if (check_->_op == details::comp::Op::Invalid) {
+                if (check_->_attr == nullptr) {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
                     return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
                 }
                 else {
                     using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
                     auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
-                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data));
                 }
                 break;
             }

--- a/example/TestMetaData.h
+++ b/example/TestMetaData.h
@@ -1,13 +1,52 @@
 #pragma once
-// #include "../include/details/MetaData.h"
-#include <DecisionTree/details/MetaData.h>
+#include "../include/details/MetaData.h"
+// #include <DecisionTree/details/MetaData.h>
 
 enum Tint
 {
     INT = 4
 };
+
+struct Data 
+{
+    int id = 1001;
+    int ival = 2;
+    double dval = 2.5;
+    std::string sval = "ass";
+
+    int getI() const { return ival; }
+    double getD() const { return dval; }
+    const std::string& getS() const { return sval; }
+};
+
+static bool checkInt(const Data& d, int q2)
+{
+    return d.getI() <= q2;
+}
+
+static bool checkDouble(const Data& d, double p2)
+{
+    return d.getD() < p2;
+}
+
+static bool checkString(const Data& d, const std::string& s)
+{
+    return s.size() <= d.getS().size();
+}
+
+static bool checkEnum(const Data& d, Tint t)
+{
+    return d.getD() <= (int)t;
+}
+
+static bool checkIntP(const Data& d, int* p2)
+{
+    if (p2 == nullptr)
+        return false;
+    return d.getD() <= *p2;
+}
     
-RegisterMetaType(Test, int,
+RegisterMetaType(Test, Data,
     ((char,         CHAR))
     ((int,          INT))
     ((double,       DOUBLE))
@@ -28,7 +67,7 @@ namespace decision_tree { namespace details {
 /*    struct TestMetaData
     {
         // get CheckT from Register macro. This is the type of objects that need to be checked
-        using CheckT = int;
+        using CheckT = Data;
 
         // enum of all supported types
         enum class ParamType
@@ -61,10 +100,22 @@ namespace decision_tree { namespace details {
         };
 
         // convert types to type enum
-        template<typename T>
-        struct getTypeName {
-            constexpr static auto value = ParamType::VOID;
-        };
+        template<typename Type>
+        static constexpr ParamType getTypeName() {
+            if constexpr (std::is_same_v<Type, char>) {
+                return ParamType::CHAR;
+            }
+            if constexpr (std::is_same_v<Type, int>) {
+                return ParamType::INT;
+            }
+            if constexpr (std::is_same_v<Type, double>) {
+                return ParamType::DOUBLE;
+            }
+            if constexpr (std::is_same_v<Type, std::string>) {
+                return ParamType::STRING;
+            }
+            return ParamType::VOID;
+        }
     };
 
     // specializations for MetaData::getType
@@ -85,31 +136,13 @@ namespace decision_tree { namespace details {
         using type = std::string;
     };
 
-    // // specializations for getTypeName
-    template<>
-    struct TestMetaData::getTypeName<char> {
-        constexpr static auto value = TestMetaData::ParamType::CHAR;
-    };
-    template<>
-    struct TestMetaData::getTypeName<int> {
-        constexpr static auto value = TestMetaData::ParamType::INT;
-    };
-    template<>
-    struct TestMetaData::getTypeName<double> {
-        constexpr static auto value = TestMetaData::ParamType::DOUBLE;
-    };
-    template<>
-    struct TestMetaData::getTypeName<std::string> {
-        constexpr static auto value = TestMetaData::ParamType::STRING;
-    };
-
     template<>
     struct MetaDataUtil<TestMetaData>
     {
         static bool is_same(const ConditionCheck<TestMetaData>* c1, const ConditionCheck<TestMetaData>* c2) {
-            if (c1->_type != c2->_type || c1->_checker != c2->_checker)
+            if (c1->_targetType != c2->_targetType || c1->_checker != c2->_checker || c1->_attr != c2->_attr || c1->_op != c2->_op)
                 return false;
-            switch (c1->_type)
+            switch (c1->_targetType)
             {
                 case TestMetaData::ParamType::CHAR:
                 {
@@ -139,25 +172,39 @@ namespace decision_tree { namespace details {
         }
 
         template<typename Target>
-        static ConditionCheck<TestMetaData>* buildCheck(bool(*checker_)(const typename TestMetaData::CheckT&, std::conditional_t<std::is_compound_v<Target> && !std::is_enum_v<Target>, const Target&, Target>), const Target& target_)
+        static ConditionCheck<TestMetaData>* buildCheck(bool(*checker_)(const typename TestMetaData::CheckT&, std::conditional_t<!utils::pass_by_value_v<Target>, const Target&, Target>), const Target& target_)
         {
             auto check = new _ConditionCheck<TestMetaData, std::decay_t<Target>>();
-            check->_type = TestMetaData::getTypeName<Target>::value;
-            check->_checker = checker_;
+            check->_targetType = TestMetaData::getTypeName<Target>();
+            check->_checker._userChecker = checker_;
             check->_data = target_;
+            return (ConditionCheck<TestMetaData>*)check;
+        }
+
+        template<typename Target>
+        static ConditionCheck<TestMetaData>* buildCompare(details::utils::member_attr_func_t<TestMetaData::CheckT, std::conditional_t<!utils::pass_by_value_v<Target>, const Target&, Target>> attr_, const Target& target_, details::comp::Op op_)
+        {
+            auto check = new _ConditionCheck<TestMetaData, std::decay_t<Target>>();
+            check->_targetType = TestMetaData::getTypeName<Target>();
+            check->_op = op_;
+            check->_data = target_;
+            check->_checker._comp = &comp::compare<Target>;
+            check->_attr = attr_;
             return (ConditionCheck<TestMetaData>*)check;
         }
 
         static ConditionCheck<TestMetaData>* copy(ConditionCheck<TestMetaData>* check_)
         {
-            switch (check_->_type)
+            switch (check_->_targetType)
             {
             case TestMetaData::ParamType::CHAR:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::CHAR>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
-                in_check->_type = check_->_type;
-                in_check->_checker = (typename _ConditionCheck<TestMetaData, type>::Checker)check_->_checker;
+                in_check->_targetType = check_->_targetType;
+                in_check->_op = check_->_op;
+                in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
                 return (ConditionCheck<TestMetaData>*)in_check;
                 break;
@@ -166,8 +213,10 @@ namespace decision_tree { namespace details {
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::INT>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
-                in_check->_type = check_->_type;
-                in_check->_checker = (typename _ConditionCheck<TestMetaData, type>::Checker)check_->_checker;
+                in_check->_targetType = check_->_targetType;
+                in_check->_op = check_->_op;
+                in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
                 return (ConditionCheck<TestMetaData>*)in_check;
                 break;
@@ -176,8 +225,10 @@ namespace decision_tree { namespace details {
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::DOUBLE>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
-                in_check->_type = check_->_type;
-                in_check->_checker = (typename _ConditionCheck<TestMetaData, type>::Checker)check_->_checker;
+                in_check->_targetType = check_->_targetType;
+                in_check->_op = check_->_op;
+                in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
                 return (ConditionCheck<TestMetaData>*)in_check;
                 break;
@@ -186,8 +237,10 @@ namespace decision_tree { namespace details {
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::STRING>::type;
                 auto in_check = new _ConditionCheck<TestMetaData, type>();
-                in_check->_type = check_->_type;
-                in_check->_checker = (typename _ConditionCheck<TestMetaData, type>::Checker)check_->_checker;
+                in_check->_targetType = check_->_targetType;
+                in_check->_op = check_->_op;
+                in_check->_attr = (typename _ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                memcpy(in_check->_checker._checkerData, &check_->_checker, sizeof(check_->_checker));
                 in_check->_data = *((type*)check_->_data);
                 return (ConditionCheck<TestMetaData>*)in_check;
                 break;
@@ -198,7 +251,7 @@ namespace decision_tree { namespace details {
 
         static void freeCheck(ConditionCheck<TestMetaData>* check_)
         {
-            switch (check_->_type) {
+            switch (check_->_targetType) {
                 case TestMetaData::ParamType::CHAR:
                 {
                     // std::cout << "Clear _ConditionCheck<CheckT, char>\n";
@@ -232,39 +285,66 @@ namespace decision_tree { namespace details {
 
         static bool applyCheck(const typename TestMetaData::CheckT& t_, ConditionCheck<TestMetaData>* check_)
         {
-            switch (check_->_type)
+            switch (check_->_targetType)
             {
             case TestMetaData::ParamType::CHAR:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::CHAR>::type;
-                using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
-                return ((Checker)check_->_checker)(t_, *((type*)check_->_data));
+                if (check_->_op == details::comp::Op::Invalid) {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
+                    return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
+                }
+                else {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
+                    auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                }
                 break;
             }
             case TestMetaData::ParamType::DOUBLE:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::DOUBLE>::type;
-                using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
-                return ((Checker)check_->_checker)(t_, *((type*)check_->_data));
+                if (check_->_op == details::comp::Op::Invalid) {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
+                    return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
+                }
+                else {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
+                    auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                }
                 break;
             }
             case TestMetaData::ParamType::INT:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::INT>::type;
-                using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
-                return ((Checker)check_->_checker)(t_, *((type*)check_->_data));
+                if (check_->_op == details::comp::Op::Invalid) {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
+                    return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
+                }
+                else {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
+                    auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                }
                 break;
             }
             case TestMetaData::ParamType::STRING:
             {
                 using type = TestMetaData::getType<TestMetaData::ParamType::STRING>::type;
-                using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
-                return ((Checker)check_->_checker)(t_, *((type*)check_->_data));
+                if (check_->_op == details::comp::Op::Invalid) {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Checker;
+                    return details::utils::proxy_call((Checker)check_->_checker, t_, *((type*)check_->_data));
+                }
+                else {
+                    using Checker = typename _ConditionCheck<TestMetaData, type>::Comp;
+                    auto attrfunc = (_ConditionCheck<TestMetaData, type>::AttrFunc)check_->_attr;
+                    return details::utils::proxy_call_with_attribute((Checker)check_->_checker, t_, attrfunc, *((type*)check_->_data), check_->_op);
+                }
                 break;
             }
             }
             return false;
         }
-    };
-*/
+    };*/
 }}

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,64 +1,37 @@
-// #include "../include/DecisionTree.h"
-#include <DecisionTree/DecisionTree.h>
+#include "../include/DecisionTree.h"
+// #include <DecisionTree/DecisionTree.h>
 #include "TestMetaData.h"
 #include <iostream>
 #include <vector>
 #include <functional>
 #include <chrono>
 
-static bool checkInt(const int& q1, int q2)
-{
-    return q1 <= q2;
-}
-
-static bool checkDouble(const int& p1, double p2)
-{
-    return p1 < p2;
-}
-
-static bool checkString(const int& p1, const std::string& s)
-{
-    return s.size() <= p1;
-}
-
-static bool checkEnum(const int& p1, Tint t)
-{
-    return p1 <= (int)t;
-}
-
-static bool checkIntP(const int& p1, int* p2)
-{
-    if (p2 == nullptr)
-        return false;
-    return p1 <= *p2;
-}
 
 int main()
 {
 
     int *p1 = new int(25), *p2 = new int(28);
     int *i1 = new int(3), *i2 = new int(4);
-    int a = 2, &ra = a;
-    decision_tree::DecisionTree<decision_tree::details::TestMetaData, decision_tree::details::MetaDataUtil<decision_tree::details::TestMetaData>, int> dt;
-    decision_tree::Rule<decision_tree::details::TestMetaData, decision_tree::details::MetaDataUtil<decision_tree::details::TestMetaData>, int> rule1;
-    decision_tree::Rule<decision_tree::details::TestMetaData, decision_tree::details::MetaDataUtil<decision_tree::details::TestMetaData>, int> rule2;
-    rule1.addCheck(checkInt, a);
+    Data d1, d2;
+    d2.id = 1002;
+    decision_tree::DecisionTree<decision_tree::details::TestMetaData, decision_tree::details::MetaDataUtil<decision_tree::details::TestMetaData>, Data> dt;
+    decision_tree::Rule<decision_tree::details::TestMetaData, decision_tree::details::MetaDataUtil<decision_tree::details::TestMetaData>, Data> rule1;
+    decision_tree::Rule<decision_tree::details::TestMetaData, decision_tree::details::MetaDataUtil<decision_tree::details::TestMetaData>, Data> rule2;
+    rule1.addCheck(checkInt, 2);
     rule1.addCheck(checkInt, 3);
-    rule1.addCheck(checkDouble, 2.5);
+    rule1.addCheck(checkDouble, 2.8);
     rule1.addCheck(checkString, "as");
-    rule1.addCheck(checkEnum, Tint::INT);
-    rule1.setData(p1);
+    rule1.addCompare(&Data::getI, 2, decision_tree::details::comp::Op::LessEqual);
+    rule1.addCompare(&Data::getI, 2, decision_tree::details::comp::Op::GreaterEqual);
+    rule1.addCompare(&Data::getS, std::string("ass"), decision_tree::details::comp::Op::Equal);
+    rule1.addCompare(&Data::getD, 1.8, decision_tree::details::comp::Op::Greater);
+    rule1.setData(&d1);
     rule2.addCheck(checkInt, 2);
-    rule2.addCheck(checkDouble, 2.2);
+    rule2.addCheck(checkDouble, 2.6);
     rule2.addCheck(checkDouble, 2.8);
     rule2.addCheck(checkString, "as");
     rule2.addCheck(checkDouble, 23);
-    rule2.addCheck(checkIntP, i1);
-    rule2.addCheck(checkIntP, i2);
-    // rule2.addCheck(checkString, "ass1");
-    // rule2.addCheck(checkDouble, 3);
-    // rule2.addCheck(checkString, "ass4");
-    rule2.setData(p2);
+    rule2.setData(&d2);
     dt.addRule(rule1);
     dt.addRule(rule2);
     dt.addRule(rule2);
@@ -67,19 +40,14 @@ int main()
     dt.addRule(rule2);
     dt.addRule(rule2);
     dt.prepare();
-    std::vector<int*> ret;
+    std::vector<Data*> ret;
     ret.reserve(16);
     auto start = std::chrono::high_resolution_clock::now();
-    // for (int j=0; j<100; j++)
-    // {
-    //     dt.apply(j, ret);
-    //     ret.clear();
-    // }
-    dt.apply(2, ret);
+    dt.apply(d1, ret);
     auto end = std::chrono::high_resolution_clock::now();
     std::cout << "Return " << ret.size() << " results\n";
     for (auto data : ret) {
-        std::cout << *data << std::endl;
+        std::cout << data->id << std::endl;
     }
     std::cout << "Eclipse time: " << (end-start).count() << "ns\n";
     delete p1, p2;

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -21,10 +21,10 @@ int main()
     rule1.addCheck(checkInt, 3);
     rule1.addCheck(checkDouble, 2.8);
     rule1.addCheck(checkString, "as");
-    rule1.addCompare(&Data::getI, 2, decision_tree::details::comp::Op::LessEqual);
-    rule1.addCompare(&Data::getI, 2, decision_tree::details::comp::Op::GreaterEqual);
-    rule1.addCompare(&Data::getS, std::string("ass"), decision_tree::details::comp::Op::Equal);
-    rule1.addCompare(&Data::getD, 1.8, decision_tree::details::comp::Op::Greater);
+    rule1.addCompare(&Data::getI, 2, decision_tree::details::comp::Operator::LessEqual{});
+    rule1.addCompare(&Data::getI, 2, decision_tree::details::comp::Operator::GreaterEqual{});
+    rule1.addCompare(&Data::getS, std::string("ass"), decision_tree::details::comp::Operator::Equal{});
+    rule1.addCompare(&Data::getD, 1.8, decision_tree::details::comp::Operator::Greater{});
     rule1.setData(&d1);
     rule2.addCheck(checkInt, 2);
     rule2.addCheck(checkDouble, 2.6);

--- a/include/Rule.h
+++ b/include/Rule.h
@@ -46,6 +46,15 @@ namespace decision_tree {
             return check;
         }
 
+        template<typename AttrFunc, typename Target>
+        ConditionCheck* addCompare(AttrFunc attr_, Target target_, details::comp::Op op_) {
+            static_assert(std::is_member_function_pointer_v<AttrFunc>);
+            static_assert(std::is_same_v<details::utils::class_for_mem_func_t<AttrFunc>, CheckT>);
+            auto check = MetaDataUtil::buildCompare(attr_, target_, op_);
+            _checks.push_back(check);
+            return check;
+        }
+
         void setData(DataType* data_) {
             _data = data_;
         }

--- a/include/Rule.h
+++ b/include/Rule.h
@@ -2,6 +2,7 @@
 #include "details/MetaData.h"
 #include <boost/dynamic_bitset.hpp>
 #include <vector>
+#include <cassert>
 
 namespace decision_tree {
 
@@ -46,10 +47,14 @@ namespace decision_tree {
             return check;
         }
 
-        template<typename AttrFunc, typename Target>
-        ConditionCheck* addCompare(AttrFunc attr_, Target target_, details::comp::Op op_) {
+        template<typename AttrFunc, typename Target, typename Op>
+        ConditionCheck* addCompare(AttrFunc attr_, Target target_, Op op_) {
             static_assert(std::is_member_function_pointer_v<AttrFunc>);
             static_assert(std::is_same_v<details::utils::class_for_mem_func_t<AttrFunc>, CheckT>);
+            assert(attr_ != nullptr);
+            if (attr_ == nullptr) {
+                return nullptr;
+            }
             auto check = MetaDataUtil::buildCompare(attr_, target_, op_);
             _checks.push_back(check);
             return check;

--- a/include/details/Compare.h
+++ b/include/details/Compare.h
@@ -3,51 +3,34 @@
 
 namespace decision_tree { namespace details { namespace comp {
 
-    enum class Op {
-        Invalid,
-        Greater,
-        Less,
-        GreaterEqual,
-        LessEqual,
-        Equal,
-        In,
-        NotIn
-    };
-
-    template<typename T>
-    bool compare(const T& t1_, const T& t2_, Op op_) {
-        switch (op_)
-        {
-        case Op::Equal:
-            return t1_ == t2_;
-        case Op::Greater:
-            return t1_ > t2_;
-        case Op::GreaterEqual:
-            return t1_ >= t2_;
-        case Op::Less:
-            return t1_ < t2_;
-        case Op::LessEqual:
-            return t1_ <= t2_;
-        default:
-            assert(false && "Op not supported");
-            break;
-        }
-        return false;
+    namespace Operator {
+        struct Greater {};
+        struct GreaterEqual {};
+        struct Less {};
+        struct LessEqual {};
+        struct Equal {};
     }
 
-    template<typename T, template<typename _T> typename Range>
-    bool compare(const T& t_, const Range<T>& range_, Op op_) {
-        auto&& iter = range_.find(t_);
-        switch (op_)
-        {
-        case Op::In:
-            return iter != range_.end();
-        case Op::NotIn:
-            return iter == range_.end();
-        default:
-            assert(false && "Op not supported");
-            break;
+    template<typename T, typename Op>
+    bool compare(const T& t1_, const T& t2_) {
+        if constexpr (std::is_same_v<Op, Operator::Equal>) {
+            return t1_ == t2_;
         }
-        return false;
+        if constexpr (std::is_same_v<Op, Operator::Greater>) {
+            return t1_ > t2_;
+        }
+        if constexpr (std::is_same_v<Op, Operator::GreaterEqual>) {
+            return t1_ >= t2_;
+        }
+        if constexpr (std::is_same_v<Op, Operator::Less>) {
+            return t1_ < t2_;
+        }
+        if constexpr (std::is_same_v<Op, Operator::LessEqual>) {
+            return t1_ <= t2_;
+        }
+        else {
+            assert(false && "Should never be here");
+            return false;
+        }
     }
 }}}

--- a/include/details/Compare.h
+++ b/include/details/Compare.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <cassert>
+
+namespace decision_tree { namespace details { namespace comp {
+
+    enum class Op {
+        Invalid,
+        Greater,
+        Less,
+        GreaterEqual,
+        LessEqual,
+        Equal,
+        In,
+        NotIn
+    };
+
+    template<typename T>
+    bool compare(const T& t1_, const T& t2_, Op op_) {
+        switch (op_)
+        {
+        case Op::Equal:
+            return t1_ == t2_;
+        case Op::Greater:
+            return t1_ > t2_;
+        case Op::GreaterEqual:
+            return t1_ >= t2_;
+        case Op::Less:
+            return t1_ < t2_;
+        case Op::LessEqual:
+            return t1_ <= t2_;
+        default:
+            assert(false && "Op not supported");
+            break;
+        }
+        return false;
+    }
+
+    template<typename T, template<typename _T> typename Range>
+    bool compare(const T& t_, const Range<T>& range_, Op op_) {
+        auto&& iter = range_.find(t_);
+        switch (op_)
+        {
+        case Op::In:
+            return iter != range_.end();
+        case Op::NotIn:
+            return iter == range_.end();
+        default:
+            assert(false && "Op not supported");
+            break;
+        }
+        return false;
+    }
+}}}

--- a/include/details/Utils.h
+++ b/include/details/Utils.h
@@ -1,18 +1,71 @@
 #pragma once
 #include <type_traits>
+#include <utility>
+#include <cassert>
 
 namespace decision_tree { namespace details { namespace utils {
 
+    // helper class for invalid input
+    struct Invalid {};
+
+    // check if a specific type T is in the tuple
     template <typename T, typename Tuple>
     struct has_type;
     template <typename T, typename... Us>
     struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...> {};
 
+    // check if a type T should be passed to functions by value 
     template<typename T>
     struct pass_by_value
     {
-        constexpr static auto value = std::is_fundamental_v<T> || std::is_pointer_v<T> || std::is_enum_v<T>;
+        constexpr static auto value = !std::is_class_v<T>;
     };
     template<typename T>
     constexpr inline bool pass_by_value_v = pass_by_value<T>::value;
+
+    // build attribute function type from Class/R if valid, otherwise return Invalid::*
+    template<typename Class, typename R, typename Enable = void>
+    struct member_attr_func {
+        using type = R(Class::*)() const;
+    };
+    template<typename Class, typename R>
+    struct member_attr_func<Class, R, std::enable_if_t<!std::is_class_v<Class>>> {
+        using type = void(Invalid::*)() const;
+    };
+    template<typename Class, typename R>
+    using member_attr_func_t = typename member_attr_func<Class, R>::type;
+
+    // get class type from member function
+    template<typename MemFunc>
+    struct class_for_mem_func;
+    template<typename R, typename Class, typename ...Args>
+    struct class_for_mem_func<R(Class::*)(Args... args)> {
+        using type = Class;
+    };
+    template<typename R, typename Class, typename ...Args>
+    struct class_for_mem_func<R(Class::*)(Args... args) const> {
+        using type = Class;
+    };
+    template<typename MemFunc>
+    using class_for_mem_func_t = typename class_for_mem_func<MemFunc>::type;
+    
+    // helper to call func with args
+    template<typename R, typename ...FuncArgs, typename ...Args>
+    R proxy_call(R (* func)(FuncArgs...), Args&&... args) {
+        return func(std::forward<Args>(args)...);
+    }
+
+    // helper to call func with t.attr() and args
+    template<typename R, typename T, typename AttrFunc, typename ...FuncArgs, typename ...Args>
+    R proxy_call_with_attribute(R (* func)(FuncArgs...), const T& t, AttrFunc attr, Args&&... args) {
+        static_assert(std::is_member_function_pointer_v<AttrFunc>);
+        if constexpr (std::is_class_v<T>) {
+            return func((t.*attr)(), std::forward<Args>(args)...);
+        }
+        else {
+            assert(false && "Should never be here");
+            return R{};
+        }
+    }
+
 }}}


### PR DESCRIPTION
***All changes are updated in `TestMetaData`***

## Support passing in operator

Use `Rule::addCompare` to add a simple comparison. `Attribute` function, `target` and `op` must be given. The result of attribute function would be compared with target directly according to op.

Examples and implementation details are given in `TestMetaData.h` and `example/main.cpp`

## Limitations

2 important limitations:

1. Currently the result of attribute function and target must have the same type. 
2. The attribute function must either return by value (for non-class types, pointers) or by `const&` (for class types). The type of return value is decided internally according to the target type and all types violating the rule shall cause a compiling error. i.e. a attribute function returning `const int` or `std::string_view` would not build. I'd prefer to let the user decide whether a type should be used by value/ref in `RegisterMetaType`